### PR TITLE
Assert object properties are valid

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,66 @@ tap.test('length', function (t) {
   t.end()
 })
 
+tap.test('assert object properties', function (t) {
+  try {
+    varstruct([ { foo: 'bar' } ])
+    t.fail('error not thrown')
+  } catch (err) {
+    t.ok(err, 'error thrown')
+    t.equal(err.message, 'Item missing "name" property', 'correct error message')
+  }
+
+  try {
+    varstruct([ { name: 'foo' } ])
+    t.fail('error not thrown')
+  } catch (err) {
+    t.ok(err, 'error thrown')
+    t.equal(err.message, 'Item "foo" has invalid codec', 'correct error message')
+  }
+
+  try {
+    varstruct([ { name: 'foo', type: {} } ])
+    t.fail('error not thrown')
+  } catch (err) {
+    t.ok(err, 'error thrown')
+    t.equal(err.message, 'Item "foo" has invalid codec', 'correct error message')
+  }
+
+  try {
+    varstruct([ { name: 'foo', type: {
+      decode: function () {}
+    } } ])
+    t.fail('error not thrown')
+  } catch (err) {
+    t.ok(err, 'error thrown')
+    t.equal(err.message, 'Item "foo" has invalid codec', 'correct error message')
+  }
+
+  try {
+    varstruct([ { name: 'foo', type: {
+      decode: function () {},
+      encode: function () {}
+    } } ])
+    t.fail('error not thrown')
+  } catch (err) {
+    t.ok(err, 'error thrown')
+    t.equal(err.message, 'Item "foo" has invalid codec', 'correct error message')
+  }
+
+  try {
+    varstruct([ { name: 'foo', type: {
+      decode: function () {},
+      encode: function () {},
+      encodingLength: function () {}
+    } } ])
+    t.pass('error not thrown')
+  } catch (err) {
+    t.fail('error thrown')
+  }
+
+  t.end()
+})
+
 tap.test('bitcoin transactions', function (t) {
   var VarUIntBitcoin = require('varuint-bitcoin')
   var TxInput = varstruct([

--- a/types/object.js
+++ b/types/object.js
@@ -4,6 +4,15 @@ var reduce = require('../reduce')
 module.exports = function (items) {
   // copy items for freezing
   items = items.map(function (item) {
+    if (!item.name) {
+      throw new Error('Item missing "name" property')
+    }
+    if (!item.type ||
+    typeof item.type.decode !== 'function' ||
+    typeof item.type.encode !== 'function' ||
+    typeof item.type.encodingLength !== 'function') {
+      throw new Error('Item "' + item.name + '" has invalid codec')
+    }
     return { name: item.name, type: item.type }
   })
 


### PR DESCRIPTION
This PR adds checks to the `object` codec, so that each property is ensured to have a `name` property, and a `type` property with `decode`, `encode`, and `encodingLength` function properties. This makes so an error will be thrown at struct creation-time, rather than eventually when encoding or decoding.